### PR TITLE
Remove game art from game list

### DIFF
--- a/320x240/SimUI/theme.ini
+++ b/320x240/SimUI/theme.ini
@@ -38,6 +38,7 @@ art_max_h = 160
 art_text_distance_from_picture = 999
 art_text_line_separation = 0
 art_text_font_size = 0
+show_art=0
 
 ;System Picture
 system_w = 32


### PR DESCRIPTION
Added show_art=0 which removes the game art from the game list without hiding the heart (favorite) symbol, which now is centered and it's size is dependant on the image size. 